### PR TITLE
Use Amount Allocations object as Marketplace API is deprecated

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -140,6 +140,7 @@ module ActiveMerchant #:nodoc:
         add_3ds(post, options)
         add_metadata(post, options, payment_method)
         add_processing_channel(post, options)
+        add_amount_allocations_data(post, options)
         add_marketplace_data(post, options)
         add_recipient_data(post, options)
         add_processing_data(post, options)
@@ -475,6 +476,14 @@ module ActiveMerchant #:nodoc:
         if options[:marketplace]
           post[:marketplace] = {}
           post[:marketplace][:sub_entity_id] = options[:marketplace][:sub_entity_id] if options[:marketplace][:sub_entity_id]
+        end
+      end
+
+      def add_amount_allocations_data(post, options)
+        return unless options[:amount_allocations]&.is_a?(Array)
+
+        post[:amount_allocations] = options[:amount_allocations].select do |v|
+          v[:id].present? && v[:amount].present?
         end
       end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -84,6 +84,14 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       email: 'longbob.longsen@example.com',
       processing_channel_id: 'pc_lxgl7aqahkzubkundd2l546hdm'
     }
+    @options_for_verify = @options.merge({
+      amount_allocations: [
+        {
+          id: 'ent_123',
+          amount: 0
+        }
+      ]
+    })
     @additional_options = @options.merge(
       card_on_file: true,
       transaction_indicator: 2,
@@ -1081,13 +1089,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = @gateway.verify(@credit_card, @options)
+    response = @gateway.verify(@credit_card, @options_for_verify)
     assert_success response
     assert_match %r{Succeeded}, response.message
   end
 
   def test_successful_verify_via_oauth
-    response = @gateway_oauth.verify(@credit_card, @options)
+    response = @gateway_oauth.verify(@credit_card, @options_for_verify)
     assert_success response
     assert_match %r{Succeeded}, response.message
     assert_not_nil response.responses.first.params['access_token']
@@ -1095,7 +1103,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    response = @gateway.verify(@declined_card, @options)
+    response = @gateway.verify(@declined_card, @options_for_verify)
     assert_failure response
     assert_match %r{request_invalid: card_number_invalid}, response.message
   end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -477,6 +477,46 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_with_additional_options_ammount_allocation
+    response = stub_comms(@gateway, :ssl_request) do
+      options = {
+        card_on_file: true,
+        transaction_indicator: 2,
+        previous_charge_id: 'pay_123',
+        processing_channel_id: 'pc_123',
+        amount_allocations: [
+          {
+            id: 'ent_123',
+            amount: 49
+          },
+          {
+            id: 'ent_456',
+            amount: 51
+          },
+          {
+            id: 'ent_789'
+          }
+        ]
+      }
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(%r{"stored":"true"}, data)
+      assert_match(%r{"payment_type":"Recurring"}, data)
+      assert_match(%r{"previous_payment_id":"pay_123"}, data)
+      assert_match(%r{"processing_channel_id":"pc_123"}, data)
+      assert_match(/"amount_allocations\":\[{\"id\":\"ent_123\",\"amount\":49},{\"id\":\"ent_456\",\"amount\":51}\]/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
+
+    capture = stub_comms(@gateway, :ssl_request) do
+      @gateway.capture(@amount, response.authorization)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
   def test_successful_purchase_with_stored_credentials
     initial_response = stub_comms(@gateway, :ssl_request) do
       initial_options = {


### PR DESCRIPTION
## Description
Use Amount Allocations object as Marketplace API is deprecated

## Reference
- [Trello Card](https://trello.com/c/qrs6MZRw/4378-activemerchantold-add-phonenumber-and-risk)