### PR TITLE
Add Risk object

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -134,6 +134,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
         add_extra_customer_data(post, payment_method, options)
+        add_risk_data(post, options)
         add_shipping_address(post, options)
         add_stored_credential_options(post, options)
         add_transaction_data(post, options)
@@ -322,6 +323,15 @@ module ActiveMerchant #:nodoc:
         post[:source][:phone][:number] = options[:phone] || options.dig(:billing_address, :phone) || options.dig(:billing_address, :phone_number)
         post[:source][:phone][:country_code] = options[:phone_country_code] if options[:phone_country_code]
         post[:customer][:name] = payment_method.name if payment_method.respond_to?(:name)
+      end
+
+      def add_risk_data(post, options)
+        risk = options[:risk]
+        if risk && risk[:device_session_id]
+          post[:risk] = {}
+          post[:risk][:enabled] = risk[:enabled].nil? ? true :: risk[:enabled]
+          post[:risk][:device_session_id] = risk[:device_session_id]
+        end
       end
 
       def add_shipping_address(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -121,6 +121,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
         authentication_response_status: 'Y'
       }
     )
+    @additional_options_risk = @options.merge(
+      risk: {
+        enabled: true,
+        device_session_id: 'dsid_ipsmclhxwq72phhr32iwfvrflm'
+      }
+    )
     @extra_customer_data = @options.merge(
       phone_country_code: '1',
       phone: '9108675309'
@@ -698,6 +704,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_ip
     response = @gateway.purchase(@amount, @credit_card, ip: '96.125.185.52')
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_risk_object
+    response = gateway_oauth.purchase(@amount, @apple_pay_network_token, @additional_options_risk)
     assert_success response
     assert_equal 'Succeeded', response.message
   end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -604,6 +604,22 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_risk_data
+    stub_comms(@gateway, :ssl_request) do
+      options = {
+        risk: {
+          enabled: true,
+          device_session_id: 'dsid_ipsmclhxwq72phhr32iwfvrflm'
+        }
+      }
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['risk']['enabled'], true
+      assert_equal request['risk']['device_session_id'], 'dsid_ipsmclhxwq72phhr32iwfvrflm'
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase_with_metadata
     response = stub_comms(@gateway, :ssl_request) do
       options = {


### PR DESCRIPTION
## Description
- Enabled risk assessment
- Device Session ID generated by Risk.js

## Reference
- [Trello Card](https://trello.com/c/qrs6MZRw/4378-activemerchantold-add-phonenumber-and-risk)